### PR TITLE
Add option to specify external directories for Tesseract

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/inja"]
 	path = vendor/inja
 	url = https://github.com/pantor/inja.git
+[submodule "vendor/obs-ocr-deps"]
+	path = vendor/obs-ocr-deps
+	url = https://github.com/umireon/obs-ocr-deps.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/pantor/inja.git
 [submodule "vendor/obs-ocr-deps"]
 	path = vendor/obs-ocr-deps
-	url = https://github.com/umireon/obs-ocr-deps.git
+	url = https://github.com/occ-ai/obs-ocr-deps.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ set(BUILD_TESSERACT_FROM_SOURCE
     OFF
     CACHE STRING "Build Tessaract from tarball")
 if(BUILD_TESSERACT_FROM_SOURCE)
+  if(NOT OS_LINUX)
+    message(FATAL_ERROR "Building Tesseract from source is only supported on Linux!")
+  endif()
   include(cmake/BuildTesseract.cmake)
 else()
   include(cmake/FetchTesseract.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,14 @@ else()
   target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OpenCV)
 endif()
 
-include(cmake/FetchTesseract.cmake)
+set(BUILD_TESSERACT_FROM_SOURCE
+    OFF
+    CACHE STRING "Build Tessaract from tarball")
+if(BUILD_TESSERACT_FROM_SOURCE)
+  include(cmake/BuildTesseract.cmake)
+else()
+  include(cmake/FetchTesseract.cmake)
+endif()
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Tesseract)
 
 include(cmake/BuildInja.cmake)

--- a/cmake/BuildTesseract.cmake
+++ b/cmake/BuildTesseract.cmake
@@ -1,0 +1,52 @@
+include(FetchContent)
+
+
+set(TESSERACT_SOURCE_URL
+    ""
+    CACHE STRING "URL of a Tesseract source tarball")
+
+set(TESSERACT_SOURCE_HASH
+    ""
+    CACHE STRING "Hash of a Tesseract source tarball")
+
+set(LEPTONICA_SOURCE_URL
+    ""
+    CACHE STRING "URL of a Leptonica source tarball")
+
+set(LEPTONICA_SOURCE_HASH
+    ""
+    CACHE STRING "Hash of a Leptonica source tarball")
+
+FetchContent_Declare(
+  tesseract_source
+  URL ${TESSERACT_SOURCE_URL}
+  URL_HASH ${TESSERACT_SOURCE_HASH})
+FetchContent_Populate(tesseract_source)
+
+FetchContent_Declare(
+  leptonica_source
+  URL ${LEPTONICA_SOURCE_URL}
+  URL_HASH ${LEPTONICA_SOURCE_HASH})
+FetchContent_Populate(leptonica_source)
+
+set(BUILD_TESSERACT_BASEDIR ${CMAKE_BINARY_DIR}/build-obs-ocr-dep)
+
+set(BUILD_TESSERACT_OUTPUTS
+  ${BUILD_TESSERACT_BASEDIR}/release/tesseract/${CMAKE_BUILD_TYPE}/lib/libtesseract.a
+  ${BUILD_TESSERACT_BASEDIR}/release/tesseract/${CMAKE_BUILD_TYPE}/lib/libleptonica.a
+)
+
+set(BUILD_TESSERACT_INCLUDE_DIR ${BUILD_TESSERACT_BASEDIR}/release/tesseract/${CMAKE_BUILD_TYPE}/include)
+
+add_custom_command(
+  OUTPUT ${BUILD_TESSERACT_OUTPUTS}
+  COMMAND ${CMAKE_SOURCE_DIR}/vendor/obs-ocr-deps/build-linux.sh ${CMAKE_BUILD_TYPE} main main ${tesseract_source_SOURCE_DIR} ${leptonica_source_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/build-obs-ocr-dep
+)
+add_custom_target(build_tesseract DEPENDS ${BUILD_TESSERACT_OUTPUTS})
+
+add_library(Tesseract INTERFACE)
+add_dependencies(Tesseract build_tesseract)
+target_link_libraries(Tesseract INTERFACE ${BUILD_TESSEACT_OUTPUTS})
+target_include_directories(Tesseract SYSTEM INTERFACE ${BUILD_TESSERACT_INCLUDE_DIR})
+

--- a/cmake/BuildTesseract.cmake
+++ b/cmake/BuildTesseract.cmake
@@ -1,6 +1,5 @@
 include(FetchContent)
 
-
 set(TESSERACT_SOURCE_URL
     ""
     CACHE STRING "URL of a Tesseract source tarball")
@@ -31,22 +30,19 @@ FetchContent_Populate(leptonica_source)
 
 set(BUILD_TESSERACT_BASEDIR ${CMAKE_BINARY_DIR}/build-obs-ocr-dep)
 
-set(BUILD_TESSERACT_OUTPUTS
-  ${BUILD_TESSERACT_BASEDIR}/release/tesseract/${CMAKE_BUILD_TYPE}/lib/libtesseract.a
-  ${BUILD_TESSERACT_BASEDIR}/release/tesseract/${CMAKE_BUILD_TYPE}/lib/libleptonica.a
-)
+set(BUILD_TESSERACT_OUTPUTS ${BUILD_TESSERACT_BASEDIR}/release/tesseract/${CMAKE_BUILD_TYPE}/lib/libtesseract.a
+                            ${BUILD_TESSERACT_BASEDIR}/release/tesseract/${CMAKE_BUILD_TYPE}/lib/libleptonica.a)
 
 set(BUILD_TESSERACT_INCLUDE_DIR ${BUILD_TESSERACT_BASEDIR}/release/tesseract/${CMAKE_BUILD_TYPE}/include)
 
 add_custom_command(
   OUTPUT ${BUILD_TESSERACT_OUTPUTS}
-  COMMAND ${CMAKE_SOURCE_DIR}/vendor/obs-ocr-deps/build-linux.sh ${CMAKE_BUILD_TYPE} main main ${tesseract_source_SOURCE_DIR} ${leptonica_source_SOURCE_DIR}
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/build-obs-ocr-dep
-)
+  COMMAND ${CMAKE_SOURCE_DIR}/vendor/obs-ocr-deps/build-linux.sh ${CMAKE_BUILD_TYPE} main main
+          ${tesseract_source_SOURCE_DIR} ${leptonica_source_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/build-obs-ocr-dep)
 add_custom_target(build_tesseract DEPENDS ${BUILD_TESSERACT_OUTPUTS})
 
 add_library(Tesseract INTERFACE)
 add_dependencies(Tesseract build_tesseract)
 target_link_libraries(Tesseract INTERFACE ${BUILD_TESSEACT_OUTPUTS})
 target_include_directories(Tesseract SYSTEM INTERFACE ${BUILD_TESSERACT_INCLUDE_DIR})
-


### PR DESCRIPTION
The FlatHub maintainer required us to obtain dependencies from their upstream. I have made changes to use the external tarball that is downloaded from the upstream. I use the build scripts on https://github.com/occ-ai/obs-ocr-deps and the script is not copied into this repository. The pre-downloaded tarballs can be used with CMake command as the following:

```
cmake . -B build_x86_64 -G Ninja -DQT_VERSION=6 \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DENABLE_FRONTEND_API=ON \
  -DENABLE_QT=ON \
  -DBUILD_TESSERACT_FROM_SOURCE=ON \
  -DTESSERACT_SOURCE_URL="/path/to/tesseract-5.3.3.tar.gz" \
  -DTESSERACT_SOURCE_HASH=SHA256=dc4329f85f41191b2d813b71b528ba6047745813474e583ccce8795ff2ff5681 \
  -DLEPTONICA_SOURCE_URL="/path/to/leptonica-1.84.1.tar.gz" \
  -DLEPTONICA_SOURCE_HASH=SHA256=ecd7a868403b3963c4e33623595d77f2c87667e2cfdd9b370f87729192061bef
```

Refer to https://github.com/flathub/flathub/pull/4907#discussion_r1476091615

The changes in https://github.com/occ-ai/obs-ocr-deps/pull/1 should be merged before this PR is merged.