### PR TITLE
Fix compile errors

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -1,33 +1,33 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "29.1.2",
+            "version": "30.0.2",
             "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "215f1fa5772c5dd9f3d6e35b0cb573912b00320149666a77864f9d305525504b",
-                "windows-x64": "46d451f3f42b9d2c59339ec268165849c7b7904cdf1cc2a8d44c015815a9e37d"
+                "macos": "be12c3ad0a85713750d8325e4b1db75086223402d7080d0e3c2833d7c5e83c27",
+                "windows-x64": "970058c49322cfa9cd6d620abb393fed89743ba7e74bd9dbb6ebe0ea8141d9c7"
             }
         },
         "prebuilt": {
-            "version": "2023-04-12",
+            "version": "2023-11-03",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built obs-deps",
             "hashes": {
-                "macos": "9535c6e1ad96f7d49960251e85a245774088d48da1d602bb82f734b10219125a",
-                "windows-x64": "c13a14a1acc4224b21304d97b63da4121de1ed6981297e50496fbc474abc0503"
+                "macos": "90c2fc069847ec2768dcc867c1c63b112c615ed845a907dc44acab7a97181974",
+                "windows-x64": "d0825a6fb65822c993a3059edfba70d72d2e632ef74893588cf12b1f0d329ce6"
             }
         },
         "qt6": {
-            "version": "2023-04-12",
+            "version": "2023-11-03",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos": "eb7614544ab4f3d2c6052c797635602280ca5b028a6b987523d8484222ce45d1",
-                "windows-x64": "4d39364b8a8dee5aa24fcebd8440d5c22bb4551c6b440ffeacce7d61f2ed1add"
+                "macos": "ba4a7152848da0053f63427a2a2cb0a199af3992997c0db08564df6f48c9db98",
+                "windows-x64": "bc57dedf76b47119a6dce0435a2f21b35b08c8f2948b1cb34a157320f77732d1"
             },
             "debugSymbols": {
-                "windows-x64": "f34ee5067be19ed370268b15c53684b7b8aaa867dc800b68931df905d679e31f"
+                "windows-x64": "fd8ecd1d8cd2ef049d9f4d7fb5c134f784836d6020758094855dfa98bd025036"
             }
         }
     },

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -89,7 +89,8 @@ function(_setup_obs_studio)
   execute_process(
     COMMAND "${CMAKE_COMMAND}" --build build_${arch} --target obs-frontend-api --config Debug --parallel
     WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
-    RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY)
+    RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
+    OUTPUT_QUIET)
   message(STATUS "Build ${label} (${arch}) - done")
 
   message(STATUS "Install ${label} (${arch})")

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -89,8 +89,7 @@ function(_setup_obs_studio)
   execute_process(
     COMMAND "${CMAKE_COMMAND}" --build build_${arch} --target obs-frontend-api --config Debug --parallel
     WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
-    RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
-    OUTPUT_QUIET)
+    RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY)
   message(STATUS "Build ${label} (${arch}) - done")
 
   message(STATUS "Install ${label} (${arch})")

--- a/src/tesseract-ocr-utils.cpp
+++ b/src/tesseract-ocr-utils.cpp
@@ -360,7 +360,7 @@ void tesseract_thread(void *data)
 					else if (tf->binarizationMode == 2 ||
 						 tf->binarizationMode == 3) {
 						// ensure that the block size is odd
-						uint16_t block_size = tf->binarizationBlockSize;
+						int block_size = tf->binarizationBlockSize;
 						if (tf->binarizationBlockSize % 2 == 0) {
 							block_size++;
 						}
@@ -406,7 +406,7 @@ void tesseract_thread(void *data)
 					// scale to height tf->rescaleTargetSize maintaining aspect ratio
 					cv::Mat resized;
 					float scale =
-						(float)tf->rescaleTargetSize / imageForOCR.rows;
+						(float)tf->rescaleTargetSize / (float)imageForOCR.rows;
 					cv::resize(imageForOCR, resized, cv::Size(), scale, scale);
 					imageForOCR = resized;
 				}

--- a/src/tesseract-ocr-utils.cpp
+++ b/src/tesseract-ocr-utils.cpp
@@ -405,8 +405,8 @@ void tesseract_thread(void *data)
 				if (tf->rescaleImage) {
 					// scale to height tf->rescaleTargetSize maintaining aspect ratio
 					cv::Mat resized;
-					float scale =
-						(float)tf->rescaleTargetSize / (float)imageForOCR.rows;
+					float scale = (float)tf->rescaleTargetSize /
+						      (float)imageForOCR.rows;
 					cv::resize(imageForOCR, resized, cv::Size(), scale, scale);
 					imageForOCR = resized;
 				}


### PR DESCRIPTION
I got following errors on Flatpak. This PR fixes these errors.

```
/run/build/obs-ocr/src/tesseract-ocr-utils.cpp: In function ‘void tesseract_thread(void*)’:
/run/build/obs-ocr/src/tesseract-ocr-utils.cpp:363:75: error: conversion from ‘int’ to ‘uint16_t’ {aka ‘short unsigned int’} may change value [-Werror=conversion]
  363 |                                                 uint16_t block_size = tf->binarizationBlockSize;
      |                                                                       ~~~~^~~~~~~~~~~~~~~~~~~~~
/run/build/obs-ocr/src/tesseract-ocr-utils.cpp:409:92: error: conversion from ‘int’ to ‘float’ may change value [-Werror=conversion]
  409 |                                                 (float)tf->rescaleTargetSize / imageForOCR.rows;
      |                                                                                ~~~~~~~~~~~~^~~~
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
Error: module obs-ocr: Child process exited with code 1
```